### PR TITLE
Show new duplicates

### DIFF
--- a/AnswerArea.vue
+++ b/AnswerArea.vue
@@ -1543,15 +1543,24 @@ export default {
       duplicatedStatement['position'] = 'absolute';
       duplicatedStatement['showPopup'] = theStatement['showPopup'];
       duplicatedStatement['collapsed'] = theStatement['collapsed'];
-      this.allStatements[duplicatedStatement.id] = duplicatedStatement; // now add to the keyed list
-      let baseTop = 100;
-      let baseLeft = 100;
+      duplicatedStatement['zIndex'] = 6;
       if (theStatement['parent'] == -1) {
-        baseTop = theStatement['top'];
-        baseLeft = theStatement['left'];
+        // Root elements are duplicated to bottom right
+        duplicatedStatement['top'] = theStatement['top'] + 25;
+        duplicatedStatement['left'] = theStatement['left'] + 75;
+      } else {
+        // Child elements are duplicated onto the top left of the screen, because
+        // for some reason child elements aren't stored with a 'left' and 'top' attribute
+        //
+        // Child elements **should be** duplicated to top left of their parents
+        const parentId = theStatement['parent'];
+        // console.log(this.allConnectors[parentId]);
+        duplicatedStatement['top'] = this.allConnectors[parentId]['top'] - 25;
+        duplicatedStatement['left'] = this.allConnectors[parentId]['left'] - 75;
       }
-      this.allStatements[duplicatedStatement.id]['top'] = baseTop + 25;
-      this.allStatements[duplicatedStatement.id]['left'] = baseLeft + 75;
+      // Place slightly above/to left of parent
+      // Save to relevant data structures
+      this.allStatements[duplicatedStatement.id] = duplicatedStatement;
       this.rootStatementID_set.add(duplicatedStatement.id);
       this.$emit('answerarea-state-change');
     },

--- a/RenderStatement.vue
+++ b/RenderStatement.vue
@@ -1,66 +1,69 @@
 <template>
-  <div
-    class="statement-box"
-    id="renderStatementElement"
-    :draggable="true"
-    @dragstart.stop="startDrag($event, data)"
-    @dragover.prevent
-    @dragenter.prevent="handleDragEnteringRenderStatement"
-    @dragleave.prevent="handleDragLeavingRenderStatement"
-    @drop="onDrop($event)"
-    ref="mmStatementBox"
-    :style="{
-      position: this.statementData.position,
-      left: this.statementData.left + 'px',
-      top: this.statementData.top + 'px',
-    }"
-  >
-    <div class="drag-handle">&nbsp;</div>
+  <Transition name="slide-fade" appear>
+    <div
+      class="statement-box"
+      id="renderStatementElement"
+      :draggable="true"
+      @dragstart.stop="startDrag($event, data)"
+      @dragover.prevent
+      @dragenter.prevent="handleDragEnteringRenderStatement"
+      @dragleave.prevent="handleDragLeavingRenderStatement"
+      @drop="onDrop($event)"
+      ref="mmStatementBox"
+      :style="{
+        position: this.statementData.position,
+        left: this.statementData.left + 'px',
+        top: this.statementData.top + 'px',
+        zIndex: this.statementData.zIndex,
+      }"
+    >
+      <div class="drag-handle">&nbsp;</div>
 
-    <StatementRoot
-      ref="statementRootRef"
-      v-bind="$attrs"
-      v-if="this.statementData.statementType === 0"
-      :statement-data="this.statementData"
-      @user-choice-changed="handleUserChoiceChanged"
-      @duplicate-statement="duplicateStatement"
-      @delete-statement="deleteStatement"
-      @toggle-collapsed-statement-root="toggleCollapsedStatementRoot"
-      @toggle-showPopup-fromstatementroot="toggleShowPopupStatementRoot"
-    />
-    <StatementTruth
-      ref="statementTruthRef"
-      v-bind="$attrs"
-      v-if="this.statementData.statementType === 1"
-      :statement-data="this.statementData"
-      @user-choice-changed="handleUserChoiceChanged"
-      @duplicate-statement="duplicateStatement"
-      @delete-statement="deleteStatement"
-      @toggle-collapsed-statement-truth="toggleCollapsedStatementTruth"
-    />
-    <StatementStudent
-      ref="statementStudentRef"
-      v-bind="$attrs"
-      v-if="this.statementData.statementType === 2"
-      :statement-data="this.statementData"
-      @user-choice-changed="handleUserChoiceChanged"
-      @duplicate-statement="duplicateStatement"
-      @delete-statement="deleteStatement"
-      @toggle-collapsed-statement-student="toggleCollapsedStatementStudent"
-      @toggle-showPopup-fromstatementstudent="toggleShowPopupStatementStudent"
-    />
-    <StatementFreeText
-      ref="statementFreeTextRef"
-      v-bind="$attrs"
-      v-if="this.statementData.statementType === 3"
-      :statement-data="this.statementData"
-      @user-input-changed="handleUserInputChanged"
-      @duplicate-statement="duplicateStatement"
-      @delete-statement="deleteStatement"
-      @toggle-collapsed-statement-freetext="toggleCollapsedStatementFreeText"
-    />
-    <div v-if="renderedText">{{ renderedText }}</div>
-  </div>
+      <StatementRoot
+        ref="statementRootRef"
+        v-bind="$attrs"
+        v-if="this.statementData.statementType === 0"
+        :statement-data="this.statementData"
+        @user-choice-changed="handleUserChoiceChanged"
+        @duplicate-statement="duplicateStatement"
+        @delete-statement="deleteStatement"
+        @toggle-collapsed-statement-root="toggleCollapsedStatementRoot"
+        @toggle-showPopup-fromstatementroot="toggleShowPopupStatementRoot"
+      />
+      <StatementTruth
+        ref="statementTruthRef"
+        v-bind="$attrs"
+        v-if="this.statementData.statementType === 1"
+        :statement-data="this.statementData"
+        @user-choice-changed="handleUserChoiceChanged"
+        @duplicate-statement="duplicateStatement"
+        @delete-statement="deleteStatement"
+        @toggle-collapsed-statement-truth="toggleCollapsedStatementTruth"
+      />
+      <StatementStudent
+        ref="statementStudentRef"
+        v-bind="$attrs"
+        v-if="this.statementData.statementType === 2"
+        :statement-data="this.statementData"
+        @user-choice-changed="handleUserChoiceChanged"
+        @duplicate-statement="duplicateStatement"
+        @delete-statement="deleteStatement"
+        @toggle-collapsed-statement-student="toggleCollapsedStatementStudent"
+        @toggle-showPopup-fromstatementstudent="toggleShowPopupStatementStudent"
+      />
+      <StatementFreeText
+        ref="statementFreeTextRef"
+        v-bind="$attrs"
+        v-if="this.statementData.statementType === 3"
+        :statement-data="this.statementData"
+        @user-input-changed="handleUserInputChanged"
+        @duplicate-statement="duplicateStatement"
+        @delete-statement="deleteStatement"
+        @toggle-collapsed-statement-freetext="toggleCollapsedStatementFreeText"
+      />
+      <div v-if="renderedText">{{ renderedText }}</div>
+    </div>
+  </Transition>
 </template>
 
 <script>
@@ -379,5 +382,15 @@ export default {
 
 .statement-box:hover .iconContainer {
   border: 5px solid rgb(12, 0, 246);
+}
+
+.slide-fade-enter-active {
+  transition: all 0.2s ease-out;
+}
+
+/* Slide in from left */
+.slide-fade-enter-from {
+  transform: translateX(-20px);
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
- Duplicate statements are given a higher z-index. Note that this is the same value for all duplicate statements, which means users can create some strange overlaps (see picture).
<img width="333" height="172" alt="Screenshot 2025-12-15 at 6 33 07 pm" src="https://github.com/user-attachments/assets/c118ad91-7965-4d7a-87af-409ec8617af8" />

- Due to the inconsistent way duplicate statements are spawning in, an animation has also been added, to draw the user's eye to the duplicate's new location.
