### PR TITLE
implements Issue #6

### DIFF
--- a/Connector.vue
+++ b/Connector.vue
@@ -42,6 +42,19 @@
         </v-btn>
       </Tooltip>
 
+      <Tooltip text="duplicate this connector and all the sub-connectors/statements">
+          <v-btn
+            size="x-small"
+            v-if="!displayOnly"
+            @click="onDuplicateConnectorClick( $event, connectorID )"
+            class="connectorButton"
+          >
+            <!--img class="statementButtonImage" src="../assets/duplicate_icon.png" alt="DuplicateStatement" /-->
+            <v-icon>mdi-content-duplicate</v-icon>
+          </v-btn>
+        </Tooltip>
+
+
       <Tooltip :text="deleteButtonTooltipText">
         <v-btn
           v-if="!displayOnly"
@@ -206,6 +219,7 @@
             "
             @connector-dropped-on-statement="connectorDroppedOnStatement"
             @duplicate-statement="duplicateStatement"
+            @duplicate-connector="duplicateConnector"
             @delete-statement="deleteStatement"
             @toggle-showPopup-fromconnector="toggleShowPopupFromConnector"
             @toggle-collapsed-renderstatement-from-connector="
@@ -350,6 +364,7 @@
             "
             @connector-dropped-on-statement="connectorDroppedOnStatement"
             @duplicate-statement="duplicateStatement"
+            @duplicate-connector="duplicateConnector"
             @delete-statement="deleteStatement"
             @toggle-showPopup-fromconnector="toggleShowPopupFromConnector"
             @toggle-collapsed-renderstatement-from-connector="
@@ -413,6 +428,7 @@ export default {
     'toggle-orientation',
     'new-connector-dropped-on-connector',
     'duplicate-statement',
+    'duplicate-connector',
     'delete-statement',
     'toggle-collapsed-renderstatement-from-connector',
     'toggle-showPopup-fromconnector',
@@ -478,11 +494,11 @@ export default {
     },
   },
   methods: {
-    duplicateStatement(id) {
+    duplicateStatement(payload) {
       // emission from either a child RenderStatement or a Connector.
       // just pass this on up the tree for the AnswerArea to deal with
-      globalConsoleLog('conn', 'Connector:duplicateStatement');
-      this.$emit('duplicate-statement', id);
+      globalConsoleLog('conn', 'Connector:duplicateStatement',payload);
+      this.$emit('duplicate-statement', payload);
     },
     deleteStatement(id) {
       // emission from either a child RenderStatement or a Connector.
@@ -1198,6 +1214,22 @@ export default {
       this.$emit('delete-child-connector', { id, parentId, position });
     },
 
+    onDuplicateConnectorClick(event, theID) {
+      globalConsoleLog('conn', 'Connector:onDuplicateConnectorClick ', theID, event.clientX, event.clientY);
+      this.$emit('duplicate-connector', {
+        id: theID,
+        posX: event.clientX,
+        posY: event.clientY
+      });
+
+    },
+
+    duplicateConnector(payload) {
+      globalConsoleLog('conn','Connector:duplicateConnector ',payload);
+      this.$emit('duplicate-connector', payload);
+    },
+
+    
     deleteConnector({ id }) {
       // Emit an event to the parent component indicating that this connector should be deleted
       this.$emit('delete-connector', { id });

--- a/RenderStatement.vue
+++ b/RenderStatement.vue
@@ -265,13 +265,14 @@ export default {
       );
     },
 
-    duplicateStatement(id) {
+    duplicateStatement(payload) {
       if (this.displayOnly) return;
 
-      console.log(
-        'RenderStatement:duplicateStatement - calling emit duplicate-statement',
+      globalConsoleLog(
+        'conn',
+        'RenderStatement:duplicateStatement - calling emit duplicate-statement', payload
       );
-      this.$emit('duplicate-statement', id); // pass it on up the chain
+      this.$emit('duplicate-statement', payload); // pass it on up the chain
     },
 
     deleteStatement(id) {

--- a/statements/StatementFreeText.vue
+++ b/statements/StatementFreeText.vue
@@ -25,7 +25,7 @@
           </v-btn>
         </Tooltip>
 
-        <button v-if="showToggle" @click="duplicateMe" class="statementButton">
+        <button v-if="showToggle" @click="duplicateMe($event,id)" class="statementButton">
           <img
             class="duplicate-statement-button"
             src="../assets/duplicate_icon.png"
@@ -117,9 +117,15 @@ export default {
       this.userInputText = this.previousUserInput;
       this.answeredData = this.statementData;
     },
-    duplicateMe() {
-      this.$emit('duplicate-statement', [this.id]);
+    duplicateMe(event, theID) {
+      globalConsoleLog('conn', 'StatementFreeText:duplicateMe ', theID, event.clientX, event.clientY);
+      this.$emit('duplicate-statement', {
+        id: theID,
+        posX: event.clientX,
+        posY: event.clientY
+      });
     },
+
     deleteStatement() {
       // Emit an event to the parent component indicating that this statement should be deleted
       this.$emit('delete-statement', this.id);

--- a/statements/StatementRoot.vue
+++ b/statements/StatementRoot.vue
@@ -45,7 +45,7 @@
           <v-btn
             size="x-small"
             v-if="showToggle && !displayOnly"
-            @click="duplicateMe"
+            @click="duplicateMe($event,id)"
             class="statementButton"
           >
             <!--img class="statementButtonImage" src="../assets/duplicate_icon.png" alt="DuplicateStatement" /-->
@@ -285,9 +285,15 @@ export default {
         this.answeredData,
       ]);
     },
-    duplicateMe() {
-      this.$emit('duplicate-statement', [this.id]);
+    duplicateMe(event, theID) {
+      globalConsoleLog('conn', 'StatementRoot:duplicateMe ', theID, event.clientX, event.clientY);
+      this.$emit('duplicate-statement', {
+        id: theID,
+        posX: event.clientX,
+        posY: event.clientY
+      });
     },
+
     deleteStatement() {
       // Emit an event to the parent component indicating that this statement should be deleted
       this.$emit('delete-statement', this.id);

--- a/statements/StatementStudent.vue
+++ b/statements/StatementStudent.vue
@@ -45,7 +45,7 @@
           <v-btn
             size="x-small"
             v-if="showToggle && !displayOnly"
-            @click="duplicateMe"
+            @click="duplicateMe($event,id)"
             class="statementButton"
           >
             <!--img class="statementButtonImage" src="../assets/duplicate_icon.png" alt="DuplicateStatement" /-->
@@ -269,8 +269,13 @@ export default {
         this.answeredData,
       ]);
     },
-    duplicateMe() {
-      this.$emit('duplicate-statement', [this.id]);
+    duplicateMe(event, theID) {
+      globalConsoleLog('conn', 'StatementStudent:duplicateMe ', theID, event.clientX, event.clientY);
+      this.$emit('duplicate-statement', {
+        id: theID,
+        posX: event.clientX,
+        posY: event.clientY
+      });
     },
     deleteStatement() {
       // Emit an event to the parent component indicating that this statement should be deleted

--- a/statements/StatementTruth.vue
+++ b/statements/StatementTruth.vue
@@ -31,7 +31,7 @@
           <v-btn
             size="x-small"
             v-if="showToggle && !displayOnly"
-            @click="duplicateMe"
+            @click="duplicateMe($event,id)"
             class="statementButton"
           >
             <!--img class="statementButtonImage" src="../assets/duplicate_icon.png" alt="DuplicateStatement" /-->
@@ -194,8 +194,13 @@ export default {
       //console.log("testing if fact<",fact," is an image - result is ",isImg);
       return isImg;
     },
-    duplicateMe() {
-      this.$emit('duplicate-statement', [this.id]);
+    duplicateMe(event, theID) {
+      globalConsoleLog('conn', 'StatementTruth:duplicateMe ', theID, event.clientX, event.clientY);
+      this.$emit('duplicate-statement', {
+        id: theID,
+        posX: event.clientX,
+        posY: event.clientY
+      });
     },
     deleteStatement() {
       // Emit an event to the parent component indicating that this statement should be deleted


### PR DESCRIPTION
implemented #6 a duplicate button for connectors. It will do any part of a connector tree and creates a new connector, parented to the top level, and positioned under the cursor. This is achieved by passing up through the tree the x,y coords of the click. I modified the duplicateStatement functionality to do the same thing, w.r.t positioning it under the cursor.