### PR TITLE
fixed bug w.r.t recording of sides

### DIFF
--- a/AnswerArea.vue
+++ b/AnswerArea.vue
@@ -1121,6 +1121,7 @@ export default {
         globalConsoleLog('net', 'droppedOn_is_Statement');
         parentConnID = this.allStatements[droppedOnStatementID]['parent'];
         this.allStatements[droppedOnStatementID]['parent'] = droppedConnectorID;
+        this.allStatements[droppedOnStatementID]['side'] = targetStr;
         if (parentConnID === -1) {
           // the statement was at the top level
           globalConsoleLog('net', 'parentConnID === -1');
@@ -1139,7 +1140,6 @@ export default {
             this.allStatements[droppedOnStatementID]['left'];
           this.allStatements[droppedOnStatementID]['top'] = undefined; //since it's now part of a tree
           this.allStatements[droppedOnStatementID]['left'] = undefined; //since it's now part of a tree
-          this.allStatements[droppedOnStatementID]['side'] = 'left';
         } else {
           // we need to make the parent of the droppedOnStatement replace its left or right child with the droppedConnector
           globalConsoleLog(


### PR DESCRIPTION
fixed 2 bugs.
bug1. add connector 1. put statement X on right side. Drop connector2 onto X, so X ends up on left hand side of connector2. Move X to the right target, and it stays in left as well. further moves are compromised.
bug2. put statement X on left side of connector. Drop that onto another statement, Y, so Y ends up on the right. Now move X out, and try to move Y to the left. It stays on right. further moves are compromised.
